### PR TITLE
Update construction of giphy URLs

### DIFF
--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -86,7 +86,7 @@ export class Post extends PureComponent {
 
   onGifSelected = (gif) => {
     if (!(gif && gif.id)) return;
-    const gifUrl = `https://media.giphy.com/media/${gif.id}/giphy.gif`;
+    const gifUrl = `https://giphy.com/gifs/${gif.id}`;
     const comment = this.state.comment.trim();
     const newComment = isEmpty(comment) ? gifUrl : `${comment}\n${gifUrl}`;
     this.setState({ comment: newComment, embedUrl: gifUrl }, () => {

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -120,7 +120,7 @@ export default class PostDetails extends PureComponent {
 
   onGifSelected = (gif) => {
     if (!(gif && gif.id)) return;
-    const gifUrl = `https://media.giphy.com/media/${gif.id}/giphy.gif`;
+    const gifUrl = `https://giphy.com/gifs/${gif.id}`;
     const comment = this.state.comment.trim();
     const newComment = isEmpty(comment) ? gifUrl : `${comment}\n${gifUrl}`;
     this.setState({ comment: newComment, embedUrl: gifUrl }, () => {


### PR DESCRIPTION
Giphy links created by the app currently fail to embed for desktop users. They look like so:
https://media.giphy.com/media/JPb0gtY8CNU3EW3QvS/giphy.gif

So after doing some tinkering around with the giphy links created by the app, I managed to figure out that the following url will successfully embed for desktop:
https://giphy.com/gifs/JPb0gtY8CNU3EW3QvS

So it looks like all that needs to happen is remove the "media" prefix, change the second "media" to "gifs", and chop "giphy.gif" off the end.
![image](https://user-images.githubusercontent.com/20651295/57658338-6cf2bb00-7593-11e9-9e8f-aab812f8aa84.png)
